### PR TITLE
fix: 默认配置与 readme.md 描述不一致

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ BANGUMI_MEDIA_FOLDER = "/media"
 BANGUMI_CHECK_INTERVAL = 600 # 60 * 10 分钟检查一次
 
 # Config Setting
-BANGUMI_CONFIG_PATH = "./.config"
+BANGUMI_CONFIG_PATH = "./config"
 
 # Logger Setting
 BANGUMI_LOGGER_LEVEL = "INFO"


### PR DESCRIPTION
默认配置与 readme.md 描述不一致
#16 