### PR TITLE
修复transmission无法连接

### DIFF
--- a/bangumi/downloader/transmission.py
+++ b/bangumi/downloader/transmission.py
@@ -45,7 +45,8 @@ class TransmissionDownloader(Downloader):
         logger.info(f"Transmission Connecting to {host}:{port}")
 
         self.client = Client(
-            host=f"{host}:{port}",
+            host=host,
+            port=port,
             username=username,
             password=password,
         )


### PR DESCRIPTION
错误表现：
连接Transmission时报错
```
bangumi  | 2023-04-14 13:57:09 - [INFO] - Transmission Connecting to host.docker.internal:9091
bangumi  | Traceback (most recent call last):
bangumi  |   File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 434, in prepare_url
bangumi  |     scheme, auth, host, port, path, query, fragment = parse_url(url)
bangumi  |   File "/usr/local/lib/python3.10/site-packages/urllib3/util/url.py", line 397, in parse_url
bangumi  |     return six.raise_from(LocationParseError(source_url), None)
bangumi  |   File "<string>", line 3, in raise_from
bangumi  | urllib3.exceptions.LocationParseError: Failed to parse: http://xyqyear:[REDACTED]@host.docker.internal:9091:9091/transmission/rpc
```

可以发现，这里报错内容中解析的地址出现了两次端口号。

定位到源码为:

https://github.com/RanKKI/BangumiBot/blob/20af44a368956ee129c1d71f1412d3ebe6c6864c/bangumi/downloader/transmission.py#L45-L51

此处传入transmission客户端的host为f"{host}:{port}"。但是通过查阅transmission_rpc的代码发现，其组合链接时会使用传入的host和默认的9091端口进行拼接，导致端口号出现两次。

https://github.com/RanKKI/BangumiBot/blob/3c68aab721f2ff3ef5c2c3fc38314115537a6597/transmission_rpc/client.py#L99
![image](https://user-images.githubusercontent.com/29950788/231985872-6cc51e72-3976-4c19-9982-eea01a22c39b.png)
