### PR TITLE
修复当不使用专用的下载器而经常报错的问题

### DIFF
--- a/bangumi/bangumi.py
+++ b/bangumi/bangumi.py
@@ -87,7 +87,8 @@ class Bangumi(object):
             return
 
         # 过滤标记为做种的已完成项目
-        completed = [item for item in completed if not redisDB.is_seeding(item.hash)]
+        # there might be torrents that are already in the downloader but not added by us
+        completed = [item for item in completed if redisDB.get(item.hash) and not redisDB.is_seeding(item.hash)]
 
         if len(completed) == 0:
             return

--- a/bangumi/downloader/transmission.py
+++ b/bangumi/downloader/transmission.py
@@ -45,7 +45,8 @@ class TransmissionDownloader(Downloader):
         logger.info(f"Transmission Connecting to {host}:{port}")
 
         self.client = Client(
-            host=f"{host}:{port}",
+            host=host,
+            port=port,
             username=username,
             password=password,
         )


### PR DESCRIPTION
问题表现：如果不使用给BangumiBot专用的下载器，而是连接一个已经有种子的下载器的话，BangumiBot会尝试在redis数据库中查找这些种子的信息。因为这些种子信息在redis中不存在，rename函数中的info为None，所以会报错。

PS: 因为不知道贵项目使用的什么代码格式化器，就没有格式化这一行过长的代码。